### PR TITLE
Created a IPYNB file to generate the NDWI for the Landsat-8 data 

### DIFF
--- a/NDWI_implementation_landsat8.ipynb
+++ b/NDWI_implementation_landsat8.ipynb
@@ -1,0 +1,377 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "NDWI_implementation_landsat8.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "SO6O7_3h5WZo",
+        "outputId": "a08c481b-794c-4921-8b96-a2e8858f3a33",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "pip install rasterio"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Collecting rasterio\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/33/1a/51baddc8581ead98fcef591624b4b2521b581943a9178912a2ac576e0235/rasterio-1.1.8-1-cp36-cp36m-manylinux1_x86_64.whl (18.3MB)\n",
+            "\u001b[K     |████████████████████████████████| 18.3MB 246kB/s \n",
+            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.6/dist-packages (from rasterio) (1.18.5)\n",
+            "Requirement already satisfied: attrs in /usr/local/lib/python3.6/dist-packages (from rasterio) (20.2.0)\n",
+            "Collecting cligj>=0.5\n",
+            "  Downloading https://files.pythonhosted.org/packages/ba/06/e3440b1f2dc802d35f329f299ba96153e9fcbfdef75e17f4b61f79430c6a/cligj-0.7.0-py3-none-any.whl\n",
+            "Collecting affine\n",
+            "  Downloading https://files.pythonhosted.org/packages/ac/a6/1a39a1ede71210e3ddaf623982b06ecfc5c5c03741ae659073159184cd3e/affine-2.3.0-py2.py3-none-any.whl\n",
+            "Requirement already satisfied: click<8,>=4.0 in /usr/local/lib/python3.6/dist-packages (from rasterio) (7.1.2)\n",
+            "Collecting click-plugins\n",
+            "  Downloading https://files.pythonhosted.org/packages/e9/da/824b92d9942f4e472702488857914bdd50f73021efea15b4cad9aca8ecef/click_plugins-1.1.1-py2.py3-none-any.whl\n",
+            "Collecting snuggs>=1.4.1\n",
+            "  Downloading https://files.pythonhosted.org/packages/cc/0e/d27d6e806d6c0d1a2cfdc5d1f088e42339a0a54a09c3343f7f81ec8947ea/snuggs-1.4.7-py3-none-any.whl\n",
+            "Requirement already satisfied: pyparsing>=2.1.6 in /usr/local/lib/python3.6/dist-packages (from snuggs>=1.4.1->rasterio) (2.4.7)\n",
+            "Installing collected packages: cligj, affine, click-plugins, snuggs, rasterio\n",
+            "Successfully installed affine-2.3.0 click-plugins-1.1.1 cligj-0.7.0 rasterio-1.1.8 snuggs-1.4.7\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "yJ0Pn9-Z5lm2",
+        "outputId": "05413719-a05c-4da3-8cc6-5465c76b7035",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "import rasterio\n",
+        "print(\"Loaded successfully\")"
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Loaded successfully\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hBGXB3S1K9Gt"
+      },
+      "source": [
+        "OKEECHOBEE LAKE"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FndCZIhL80n8",
+        "outputId": "b29a592e-27ff-455e-eb20-a14f4721f936",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "#Implementation of NDWI (Leaf Moisture Content) using landsat8 dataset - Okeechobee lake\n",
+        "\n",
+        "#Importing required libraries\n",
+        "import rasterio as rio\n",
+        "import pandas as pd\n",
+        "import cv2 as cv\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "\n",
+        "#Opening the TIF file using raterio\n",
+        "Okch_R10 = '/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Okeechobee Lake, Florida/'\n",
+        "b5 = rio.open(Okch_R10 + 'LC08_L1TP_015041_20181113_20181127_01_T1_B5.TIF')\n",
+        "\n",
+        "#Reading the Required bands for the NDWI index\n",
+        "meta = b5.meta\n",
+        "print(\"Opened band 5 successfully\")\n",
+        "b6 = rio.open(Okch_R10 + 'LC08_L1TP_015041_20181113_20181127_01_T1_B6.TIF')\n",
+        "print(\"Opened band 6 successfully\")\n",
+        "b5 = b5.read()\n",
+        "b6 = b6.read()\n",
+        "\n",
+        "#Calculating NDWI (Leaf Moisture Content) \n",
+        "ndwi_lmc = (b5.astype(float) - b6.astype(float))/(b5 + b6)\n",
+        "\n",
+        "meta.update(driver = 'GTiff')\n",
+        "meta.update(dtype = rio.float32)\n",
+        "\n",
+        "#writing the band as a tiff image\n",
+        "with rio.open('/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Okeechobee Lake, Florida/ndwi_lmc.tiff', 'w', **meta) as dst:\n",
+        "    dst.write(ndwi_lmc.astype(rio.float32))\n",
+        "\n",
+        "#plt.imshow('/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Okeechobee Lake, Florida/ndwi_lmc.tiff')\n",
+        "print(\"NDWI_LMC.TIFF has been created successfuly\")"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Opened band 5 successfully\n",
+            "Opened band 6 successfully\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:23: RuntimeWarning: divide by zero encountered in true_divide\n",
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:23: RuntimeWarning: invalid value encountered in true_divide\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "NDWI_LMC.TIFF has been created successfuly\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "xDRaU6zAzYa1",
+        "outputId": "13c96ad4-876a-40f3-cf55-5169c03f508d",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "#Implementation of NDWI (Water Content) using landsat8 dataset - Okechobee lake\n",
+        "import rasterio as rio\n",
+        "import pandas as pd\n",
+        "import cv2 as cv\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "\n",
+        "#Opening the TIF file using raterio\n",
+        "Okch_R10 = '/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Okeechobee Lake, Florida/'\n",
+        "b3 = rio.open(Okch_R10 + 'LC08_L1TP_015041_20181113_20181127_01_T1_B5.TIF')\n",
+        "\n",
+        "#Reading the Required bands for the NDWI index\n",
+        "meta = b3.meta\n",
+        "print(\"Opened band 5 successfully\")\n",
+        "b5 = rio.open(Okch_R10 + 'LC08_L1TP_015041_20181113_20181127_01_T1_B6.TIF')\n",
+        "print(\"Opened band 6 successfully\")\n",
+        "b3 = b3.read()\n",
+        "b5 = b5.read()\n",
+        "\n",
+        "#Calculating NDWI (Water Content)\n",
+        "ndwi_wi = (b3.astype(float) - b5.astype(float))/(b3 + b5)\n",
+        "\n",
+        "meta.update(driver = 'GTiff')\n",
+        "meta.update(dtype = rio.float32)\n",
+        "\n",
+        "#writing the band as a tiff image\n",
+        "with rio.open('/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Okeechobee Lake, Florida/ndwi_wi.tiff', 'w', **meta) as dst:\n",
+        "    dst.write(ndwi_lmc.astype(rio.float32))\n",
+        "\n",
+        "#plt.imshow('/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Okeechobee Lake, Florida/ndwi_lmc.tiff')\n",
+        "print(\"NDWI_WC.TIFF has been created successfuly\")"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Opened band 5 successfully\n",
+            "Opened band 6 successfully\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:21: RuntimeWarning: divide by zero encountered in true_divide\n",
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:21: RuntimeWarning: invalid value encountered in true_divide\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "NDWI_WC.TIFF has been created successfuly\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9tI0EurDLHwu"
+      },
+      "source": [
+        "CHILIKHA LAKE"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zqmQ_HZNHfgQ",
+        "outputId": "9e4aa95b-8a14-4297-b74a-f6390cff1877",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "#Implementation of NDWI (Leaf Moisture Content) using landsat8 dataset - Chilikha lake\n",
+        "\n",
+        "#Importing required libraries\n",
+        "import rasterio as rio\n",
+        "import pandas as pd\n",
+        "import cv2 as cv\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "\n",
+        "#Opening the TIF file using raterio\n",
+        "Chlka_R10 = '/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Chilika Lake, Orissa/'\n",
+        "b5 = rio.open(Chlka_R10 + 'LC08_L1TP_140046_20181227_20190129_01_T1_B5.TIF')\n",
+        "\n",
+        "#Reading the Required bands for the NDWI index\n",
+        "meta = b5.meta\n",
+        "print(\"Opened band 5 successfully\")\n",
+        "b6 = rio.open(Chlka_R10 + 'LC08_L1TP_140046_20181227_20190129_01_T1_B6.TIF')\n",
+        "print(\"Opened band 6 successfully\")\n",
+        "b5 = b5.read()\n",
+        "b6 = b6.read()\n",
+        "\n",
+        "#Calculating NDWI (Leaf Moisture Content) \n",
+        "ndwi_lmc = (b5.astype(float) - b6.astype(float))/(b5 + b6)\n",
+        "\n",
+        "meta.update(driver = 'GTiff')\n",
+        "meta.update(dtype = rio.float32)\n",
+        "\n",
+        "#writing the band as a tiff image\n",
+        "with rio.open('/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Chilika Lake, Orissa/ndwi_lmc.tiff', 'w', **meta) as dst:\n",
+        "    dst.write(ndwi_lmc.astype(rio.float32))\n",
+        "\n",
+        "#plt.imshow('/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Chilika Lake, Orissa/ndwi_lmc.tiff')\n",
+        "print(\"NDWI_LMC.TIFF has been created successfuly\")"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Opened band 5 successfully\n",
+            "Opened band 6 successfully\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:23: RuntimeWarning: invalid value encountered in true_divide\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "NDWI_LMC.TIFF has been created successfuly\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FvuuXhxOHsIP",
+        "outputId": "7a9f317d-227e-40af-80fa-60093b8b57e9",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "#Implementation of NDWI (Water Content) using landsat8 dataset - Chilikha Lake\n",
+        "import rasterio as rio\n",
+        "import pandas as pd\n",
+        "import cv2 as cv\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "\n",
+        "#Opening the TIF file using raterio\n",
+        "Okch_R10 = '/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Chilika Lake, Orissa/'\n",
+        "b3 = rio.open(Chlka_R10 + 'LC08_L1TP_140046_20181227_20190129_01_T1_B3.TIF')\n",
+        "\n",
+        "\n",
+        "#Reading the Required bands for the NDWI index\n",
+        "meta = b3.meta\n",
+        "print(\"Opened band 3 successfully\")\n",
+        "b5 = rio.open(Chlka_R10 + 'LC08_L1TP_140046_20181227_20190129_01_T1_B5.TIF')\n",
+        "print(\"Opened band 5 successfully\")\n",
+        "b3 = b3.read()\n",
+        "b5 = b5.read()\n",
+        "\n",
+        "#Calculating NDWI (Water Content)\n",
+        "ndwi_wi = (b3.astype(float) - b5.astype(float))/(b3 + b5)\n",
+        "\n",
+        "meta.update(driver = 'GTiff')\n",
+        "meta.update(dtype = rio.float32)\n",
+        "\n",
+        "#writing the band as a tiff image\n",
+        "with rio.open('/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Chilika Lake, Orissa/ndwi_wi.tiff', 'w', **meta) as dst:\n",
+        "    dst.write(ndwi_lmc.astype(rio.float32))\n",
+        "\n",
+        "#plt.imshow('/content/drive/My Drive/Landsat 8_Okeechobee_20181113/Chilika Lake, Orissa/ndwi_lmc.tiff')\n",
+        "print(\"NDWI_WC.TIFF has been created successfuly\")"
+      ],
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Opened band 3 successfully\n",
+            "Opened band 5 successfully\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:22: RuntimeWarning: invalid value encountered in true_divide\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "NDWI_WC.TIFF has been created successfuly\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    }
+  ]
+}

--- a/Pilot_NDWI.ipynb
+++ b/Pilot_NDWI.ipynb
@@ -2754,7 +2754,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #3 

- Implemented the NDWI leaf moisture content using band 5 and band 6 of the Landsat 8 data provided. 

- Implemented the NDWI water content using band 3 and band 5 of the Landsat 8 data

- Both the types of NDWI are implemented for both the observation sites which are Okeechobee lake, Florida and Chilikha lake , Orissa

- This notebook does not contains the implementation of the NDCI as mapping of required bandwidths was not possible with the bands provided in the Landsat 8.

- Rasterio and Pandas are used to implement the NDWI. 

- Also,used Gimp editor to generate the PNG format of the obtained TIFF format files.

Algorithm
1. Open the required data files (TIF)
2. Read the files loaded from the previous step
3. Calculate the required index
4. Write the generated data from the previous step into the resultant TIFF file